### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * *_New_* cooltools `0.3.2`
   * *_New_* fanc `0.8.30`
   * *_Removed_* r-markdown
+* Keep fasta extension when generating bowtie2 index, fixing prefix-mismatch bug.
 
 ### `Fixed`
 

--- a/main.nf
+++ b/main.nf
@@ -360,11 +360,9 @@ if(!params.bwt2_index && params.fasta){
         file "bowtie2_index" into bwt2_index_end2end
 	file "bowtie2_index" into bwt2_index_trim
 
-        script:
-        bwt2_base = fasta.toString() - ~/(\.fa)?(\.fasta)?(\.fas)?$/
         """
         mkdir bowtie2_index
-	bowtie2-build ${fasta} bowtie2_index/${bwt2_base}
+	bowtie2-build ${fasta} bowtie2_index/${fasta}
 	"""
       }
  }


### PR DESCRIPTION
Do not truncate fasta extension when generating bowtie2 index, if the user only provides `--fasta`.