### PR TITLE
Fix aws labels cost tracking issue

### DIFF
--- a/modules/local/hicpro/dnase_mapping_stats.nf
+++ b/modules/local/hicpro/dnase_mapping_stats.nf
@@ -1,5 +1,5 @@
 process MAPPING_STATS_DNASE {
-    tag "$sample = $bam"
+    tag "${(meta.id + '_' + bam.baseName).replaceAll(/[^a-zA-Z0-9_-]/, '_')}"
     label 'process_medium'
 
     conda "bioconda::samtools=1.15.1"

--- a/modules/local/hicpro/get_restriction_fragments.nf
+++ b/modules/local/hicpro/get_restriction_fragments.nf
@@ -1,5 +1,5 @@
 process GET_RESTRICTION_FRAGMENTS {
-    tag "$res_site"
+    tag "${res_site.replaceAll(/[^a-zA-Z0-9_-]/, '_')}"
     label 'process_low'
 
     conda "conda-forge::python=3.9 conda-forge::numpy=1.22.3"

--- a/modules/nf-core/bowtie2/build/main.nf
+++ b/modules/nf-core/bowtie2/build/main.nf
@@ -1,5 +1,5 @@
 process BOWTIE2_BUILD {
-    tag "$fasta"
+    tag "${fasta.baseName.replaceAll(/[^a-zA-Z0-9_-]/, '_')}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -1,5 +1,5 @@
 process BWA_INDEX {
-    tag "$fasta"
+    tag "${fasta.baseName.replaceAll(/[^a-zA-Z0-9_-]/, '_')}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/cooler/makebins/main.nf
+++ b/modules/nf-core/cooler/makebins/main.nf
@@ -1,5 +1,5 @@
 process COOLER_MAKEBINS {
-    tag "${meta.id}}"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/custom/getchromsizes/main.nf
+++ b/modules/nf-core/custom/getchromsizes/main.nf
@@ -1,5 +1,5 @@
 process CUSTOM_GETCHROMSIZES {
-    tag "$fasta"
+    tag "${fasta.baseName.replaceAll(/[^a-zA-Z0-9_-]/, '_')}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"


### PR DESCRIPTION
AWS tag validation issues were addressed by sanitizing process tags across multiple Nextflow modules. The primary problem involved illegal characters in tag values, such as `^` in restriction sites or `=` in sample identifiers, which violate AWS resource label constraints.

A consistent sanitization pattern, `replaceAll(/[^a-zA-Z0-9_-]/, '_')`, was applied. This regex replaces any character not a letter, number, underscore, or hyphen with an underscore, ensuring AWS compliance.

Specific changes include:
*   In `modules/local/hicpro/get_restriction_fragments.nf`, the `res_site` tag was sanitized (e.g., `^GATC` becomes `_GATC`).
*   In `modules/local/hicpro/dnase_mapping_stats.nf`, `sample` and `bam` tags were combined and sanitized (e.g., `sample = file.bam` becomes `sample___file_bam`).
*   In `modules/nf-core/bwa/index/main.nf`, `modules/nf-core/bowtie2/build/main.nf`, and `modules/nf-core/custom/getchromsizes/main.nf`, `fasta` base names were sanitized (e.g., `genome.fasta` becomes `genome_fasta`).
*   In `modules/nf-core/cooler/makebins/main.nf`, a syntax error `"${meta.id}}"` was corrected to `"${meta.id}"`.

These modifications ensure all generated process tags adhere to AWS naming conventions, resolving potential deployment errors.

Closes #224 